### PR TITLE
Modified sponsors.css to centre images

### DIFF
--- a/css/sponsors.css
+++ b/css/sponsors.css
@@ -21,6 +21,10 @@
   margin: 2rem;
 }
 
+#sponsors img, #partners img{
+  vertical-align: middle;
+}
+
 .sponsor_prompt {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Seems like sponsor images aren't centred on Safari, this should do the trick.

Also seems like the `display: flex;` property is unnecessary for `.glass-card` (https://github.com/MasseyHacks/MasseyHacks-IX-Website/blob/master/css/sponsors.css#L105) while there's the `display: block !important;` Maybe a refactor could be necessary to cleanup some of the unnecessary styles?